### PR TITLE
Fix KeyError when writing solution fields (write_pdfs/write_vecs) in 3D

### DIFF
--- a/fenicsR13/solver.py
+++ b/fenicsR13/solver.py
@@ -2091,17 +2091,11 @@ class Solver:
             if dimension > 0:
                 # skip scalars
                 components = len(field.split())
+                axes = ["x", "y", "z"][:self.nsd]
                 indexMap = {
-                    1: {
-                        1: "x",
-                        2: "y"
-                    },
-                    2: {
-                        1: "xx",
-                        2: "xy",
-                        3: "yx",
-                        4: "yy",
-                    }
+                    1: {k + 1: v for k, v in enumerate(axes)},
+                    2: {k + 1: v for k, v in enumerate(
+                        a + b for a in axes for b in axes)},
                 }
                 for i in range(components):
                     fieldname = name + "_" + str(indexMap[dimension][i + 1])
@@ -2138,17 +2132,11 @@ class Solver:
         else:
             # vector or tensor
             components = len(field.split())
+            axes = ["x", "y", "z"][:self.nsd]
             indexMap = {
-                1: {
-                    1: "x",
-                    2: "y"
-                },
-                2: {
-                    1: "xx",
-                    2: "xy",
-                    3: "yx",
-                    4: "yy",
-                }
+                1: {k + 1: v for k, v in enumerate(axes)},
+                2: {k + 1: v for k, v in enumerate(
+                    a + b for a in axes for b in axes)},
             }
             for i in range(components):
                 fieldname = name + "_" + str(indexMap[dimension][i + 1])


### PR DESCRIPTION
### Problem

`Solver.__write_xdmf` and `Solver.__write_vec` build a hard-coded `indexMap`
that only contains 2D component names (`x, y` for vectors; `xx, xy, yx, yy`
for tensors):

```python
indexMap = {
    1: {1: "x", 2: "y"},
    2: {1: "xx", 2: "xy", 3: "yx", 4: "yy"},
}
for i in range(components):
    fieldname = name + "_" + str(indexMap[dimension][i + 1])
```

When the solver is run in 3D (`nsd: 3`) with `write_pdfs: True` or
`write_vecs: True`, the per-component loop dereferences
`indexMap[dimension][i + 1]` up to the field's component count — `3` for a
vector and `9` for a tensor — so it raises `KeyError` (`3` for a vector, `5`
for a tensor). The shipped 3D test inputs (`tests/3d_*`) all set
`write_pdfs`/`write_vecs` to `False`, which is why CI does not currently
exercise this path.

### Fix

Build the component-name map from the spatial dimension instead of hard-coding
the 2D names:

```python
axes = ["x", "y", "z"][:self.nsd]
indexMap = {
    1: {k + 1: v for k, v in enumerate(axes)},
    2: {k + 1: v for k, v in enumerate(
        a + b for a in axes for b in axes)},
}
```

This reproduces the previous 2D names exactly (`x, y` and
`xx, xy, yx, yy`) and adds the missing 3D names (`x, y, z` and
`xx, xy, xz, yx, yy, yz, zx, zy, zz`, matching the row-major `field.split()`
ordering already used for the error components).

A simpler change that only appended keys to a single flat dict would silently
mislabel the 2D tensor components, because a 2D tensor's four entries
(`xx, xy, yx, yy`) are not the first four of a 3D tensor's nine
(`xx, xy, xz, yx, ...`). Deriving the names from `nsd` avoids this.

### Verification

The component-naming logic was checked in isolation for both writers and all
field types: 2D output is unchanged, 3D vectors and tensors are named
correctly, and the previous code provably raises `KeyError` for the 3D cases.
`flake8` passes on the changed file.
