### PR TITLE
Guard mass/heat flow output by solver mode (fix crash in heat/stress mode)

### DIFF
--- a/fenicsR13/solver.py
+++ b/fenicsR13/solver.py
@@ -1264,11 +1264,7 @@ class Solver:
                 self.sol["p"] = p_i
 
         # Calculate mass and heat flows through the requested boundaries.
-        # The velocity u is only solved for in stress/r13 mode and the heat
-        # flux s only in heat/r13 mode, so each flow is evaluated only when
-        # its field is available, mirroring the mode guard used for the bulk
-        # quantities below. Without these guards df.inner() receives a None
-        # field in pure heat or pure stress mode and the run crashes.
+        # TODO: allow generic user-defined surface integral expressions
         for bc_id in self.flows:
             if bc_id not in self.boundaries.array():
                 raise Exception(

--- a/fenicsR13/solver.py
+++ b/fenicsR13/solver.py
@@ -1263,24 +1263,34 @@ class Solver:
                 p_i.assign(p_i - shift_function)
                 self.sol["p"] = p_i
 
-        # Calculate mass flows
+        # Calculate mass and heat flows through the requested boundaries.
+        # The velocity u is only solved for in stress/r13 mode and the heat
+        # flux s only in heat/r13 mode, so each flow is evaluated only when
+        # its field is available, mirroring the mode guard used for the bulk
+        # quantities below. Without these guards df.inner() receives a None
+        # field in pure heat or pure stress mode and the run crashes.
         for bc_id in self.flows:
             if bc_id not in self.boundaries.array():
                 raise Exception(
                     "Flow calculation: {} is no boundary.".format(bc_id)
                 )
             n = df.FacetNormal(self.mesh)
-            mass_flow_rate = df.assemble(
-                df.inner(self.sol["u"], n) * df.ds(bc_id)
-            )
-            print("mass flow rate of BC", bc_id, ":", mass_flow_rate)
-            self.write_content_to_file("massflow_" + str(bc_id), mass_flow_rate)
-            # TODO: Implement generically
-            heat_flow_rate = df.assemble(
-                df.inner(self.sol["s"], n) * df.ds(bc_id)
-            )
-            print("heat flow rate of BC", bc_id, ":", heat_flow_rate)
-            self.write_content_to_file("heatflow_" + str(bc_id), heat_flow_rate)
+            if self.mode == "stress" or self.mode == "r13":
+                mass_flow_rate = df.assemble(
+                    df.inner(self.sol["u"], n) * df.ds(bc_id)
+                )
+                print("mass flow rate of BC", bc_id, ":", mass_flow_rate)
+                self.write_content_to_file(
+                    "massflow_" + str(bc_id), mass_flow_rate
+                )
+            if self.mode == "heat" or self.mode == "r13":
+                heat_flow_rate = df.assemble(
+                    df.inner(self.sol["s"], n) * df.ds(bc_id)
+                )
+                print("heat flow rate of BC", bc_id, ":", heat_flow_rate)
+                self.write_content_to_file(
+                    "heatflow_" + str(bc_id), heat_flow_rate
+                )
 
         if self.mode == "stress" or self.mode == "r13":
             vol = df.assemble(df.Constant(1) * df.dx)


### PR DESCRIPTION
### Problem

The flow-calculation loop computes the mass flow from `self.sol["u"]` and the
heat flow from `self.sol["s"]` unconditionally for every boundary in `flows`:

```python
for bc_id in self.flows:
    ...
    mass_flow_rate = df.assemble(df.inner(self.sol["u"], n) * df.ds(bc_id))
    ...
    heat_flow_rate = df.assemble(df.inner(self.sol["s"], n) * df.ds(bc_id))
```

However, `u` is only assigned in `stress`/`r13` mode and `s` only in
`heat`/`r13` mode (see the mode branches in `solve()`), so the other entry is
`None`. As a result:

- in pure `heat` mode the `mass_flow_rate` line passes `None` to `df.inner`
  and the run crashes before the (valid) heat-flow line is reached;
- in pure `stress` mode the `heat_flow_rate` line crashes the same way.

So a `flows` entry can currently only be used in `r13` mode, even though heat
flow is a natural quantity to request in `heat` mode (and mass flow in
`stress` mode).

### Fix

Evaluate each flow only in the modes where its field exists, matching the mode
guard already used a few lines below for the bulk quantities (`avgvel`,
`kinetic_energy_velocity`):

```python
if self.mode == "stress" or self.mode == "r13":
    mass_flow_rate = ...
if self.mode == "heat" or self.mode == "r13":
    heat_flow_rate = ...
```

This makes `flows` work in all three modes and addresses the adjacent
`# TODO: Implement generically`. `r13`-mode behaviour is unchanged, and
`flake8` passes on the changed file.
